### PR TITLE
[[expression]] is ignored in first parameter of constructor

### DIFF
--- a/include/sqlpp17/prepared_statement.h
+++ b/include/sqlpp17/prepared_statement.h
@@ -88,6 +88,8 @@ namespace sqlpp
     }
 
   public:
+    //TODO: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429
+    // re-add [[maybe_unused]] when gcc bug is fixed.
     prepared_statement_t(const ResultBase& result_base, Handle handle) : _handle(std::move(handle))
     {
     }
@@ -112,6 +114,8 @@ namespace sqlpp
     }
 
   public:
+    //TODO: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429
+    // re-add [[maybe_unused]] when gcc bug is fixed.
     prepared_statement_t(const ResultBase& result_base, Handle handle)
         : _handle(std::move(handle)){}
 

--- a/include/sqlpp17/prepared_statement.h
+++ b/include/sqlpp17/prepared_statement.h
@@ -88,7 +88,7 @@ namespace sqlpp
     }
 
   public:
-    prepared_statement_t([[maybe_unused]] const ResultBase& result_base, Handle handle) : _handle(std::move(handle))
+    prepared_statement_t(const ResultBase& result_base, Handle handle) : _handle(std::move(handle))
     {
     }
   };
@@ -112,7 +112,7 @@ namespace sqlpp
     }
 
   public:
-    prepared_statement_t([[maybe_unused]] const ResultBase& result_base, Handle handle)
+    prepared_statement_t(const ResultBase& result_base, Handle handle)
         : _handle(std::move(handle)){}
 
               [[nodiscard]] decltype(auto) begin()


### PR DESCRIPTION
GCC Bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81429

It's better to sometimes have a warning than not being able
to compile at all.