### PR TITLE
Upgrade Catch2 dependency to fix building

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.0.1
+    GIT_TAG        v3.3.2
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
This PR upgrades the Catch2 dependency to the latest version, because the old version fails to compile with gcc:
```
[ 22%] Building CXX object _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o
In file included from /usr/local/projects/github/sqlpp17/build/_deps/catch2-src/src/catch2/internal/catch_clara.cpp:12:
/usr/local/projects/github/sqlpp17/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:47:14: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   47 |         std::uint64_t m_count;
      |              ^~~~~~~~
      |              wint_t
/usr/local/projects/github/sqlpp17/build/_deps/catch2-src/src/catch2/../catch2/internal/catch_string_manip.hpp:51:42: error: expected ‘)’ before ‘count’
   51 |         constexpr pluralise(std::uint64_t count, StringRef label):
      |                            ~             ^~~~~~
      |                                          )
gmake[2]: *** [_deps/catch2-build/src/CMakeFiles/Catch2.dir/build.make:328: _deps/catch2-build/src/CMakeFiles/Catch2.dir/catch2/internal/catch_clara.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1002: _deps/catch2-build/src/CMakeFiles/Catch2.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

After the upgrade the project compiles correctly.