### PR TITLE
Fix some include paths that prevent PostgreSQL tests from building

### DIFF
--- a/tests/include/core_test/insert_tests.h
+++ b/tests/include/core_test/insert_tests.h
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
-#include <sqlpp17/clause/create_table.h>
-#include <sqlpp17/clause/drop_table.h>
-#include <sqlpp17/clause/insert_into.h>
+#include <sqlpp17/core/clause/create_table.h>
+#include <sqlpp17/core/clause/drop_table.h>
+#include <sqlpp17/core/clause/insert_into.h>
 
 #include <core_test/tables/TabDepartment.h>
 

--- a/tests/postgresql/serialize/parameter.cpp
+++ b/tests/postgresql/serialize/parameter.cpp
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sqlpp17/core/name_tag.h>
 #include <sqlpp17/core/operator.h>
 #include <sqlpp17/core/parameter.h>
-
-#include <serialize/assert_equality.h>
 #include <sqlpp17/postgresql/connection.h>
+
+#include "assert_equality.h"
 
 using ::sqlpp::postgresql::context_t;
 using ::sqlpp::test::assert_equality;

--- a/tests/postgresql/usage/insert.cpp
+++ b/tests/postgresql/usage/insert.cpp
@@ -26,10 +26,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
-#include <core_test/insert_tests.h>
-
 #include <sqlpp17/postgresql/connection.h>
-#include <sqlpp17/postgresql_test/get_config.h>
+
+#include <core_test/insert_tests.h>
+#include <postgresql_test/get_config.h>
 
 namespace postgresql = sqlpp::postgresql;
 int main()

--- a/tests/postgresql/usage/select.cpp
+++ b/tests/postgresql/usage/select.cpp
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 #include <sqlpp17/postgresql/connection.h>
-#include <sqlpp17/postgresql_test/get_config.h>
 
 #include <core_test/select_tests.h>
+#include <postgresql_test/get_config.h>
 
 namespace postgresql = sqlpp::postgresql;
 int main()


### PR DESCRIPTION
It seems that some of the PostgreSQL tests have incorrect include paths. This PR corrects them.

After applying the PostgreSQL tests still fail to build with gcc, but for unrelated reasons.